### PR TITLE
[Camera] Support ISO setting on HAL3 devices under API1. Fixes JB#42952

### DIFF
--- a/services/camera/libcameraservice/api1/client2/Parameters.cpp
+++ b/services/camera/libcameraservice/api1/client2/Parameters.cpp
@@ -400,7 +400,7 @@ status_t Parameters::initialize(const CameraMetadata *info, int deviceVersion) {
     supportedISOSpeeds = "auto,ISO_HJR";
     if (sensitivityRange.count == 2 && sensitivityRange.data.i32[1] > sensitivityRange.data.i32[0]) {
     ALOGD("ISO range available: ISO%d - ISO%d", sensitivityRange.data.i32[0], sensitivityRange.data.i32[1]);
-        int32_t thisSpeed = sensitivityRange.data.i32[0];
+        int32_t thisSpeed = 100; //Always start with ISO100
         while (thisSpeed <= sensitivityRange.data.i32[1]) {
             supportedISOSpeeds.appendFormat(",ISO%d", thisSpeed);
             thisSpeed *= 2;


### PR DESCRIPTION
CameraService has compatibility layers for using HAL3 cameras under API1. Although flash, focus, white balance etc are all supported by generating old '-values' parameters, ISO control wasn't officially supported in HAL1, and was implemented independently by different vendors using different values.

This patch generates a 'iso-values' parameter by querying the max and min ISO values and generating a list. Values coming back from the client are then validated and set in the CaptureRequest object just like the others. 

A big problem with this: setting the ISO value requires all auto-exposure to be turned off, or else it has no effect. This means exposure time and frame duration are also no longer automatically controlled, and by default the frame goes very dark. Arbitrarily setting the exposure time to 1/30s improves things a little, but it's not really such a useful setting now. 